### PR TITLE
Fix compile warnings

### DIFF
--- a/lib/gettext_extract_vue.ex
+++ b/lib/gettext_extract_vue.ex
@@ -56,7 +56,7 @@ defmodule GettextExtractVue do
     parse_translate(rem, "", ctx)
   end
   def parse("", _ctx), do: nil
-  def parse(<< c, rem :: binary >>, ctx) do
+  def parse(<< _c, rem :: binary >>, ctx) do
     parse(rem, ctx)
   end
 
@@ -70,7 +70,7 @@ defmodule GettextExtractVue do
   def parse_translate(<< c, rem :: binary >>, buffer, ctx) do
     parse_translate(rem, buffer <> << c >>, ctx)
   end
-  def parse_translate("", buffer, ctx) do
+  def parse_translate("", _buffer, ctx) do
     raise "can't find closing translate tag in #{ctx.file}"
   end
 end

--- a/lib/mix/tasks/extract.ex
+++ b/lib/mix/tasks/extract.ex
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.GettextVue.Extract do
   @doc """
     load a single po file and parse the content
   """
-  def load_po(locale, file, fname) do
+  def load_po(_locale, _file, fname) do
     state =
       File.stream!(fname)
       |> Enum.reduce(%{dict: %{}}, fn (line, state) ->

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule GettextExtractVue.Mixfile do
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
The following warnings are fixed now:
```
warning: variable "c" is unused
  lib/gettext_extract_vue.ex:59

warning: variable "buffer" is unused
  lib/gettext_extract_vue.ex:73

warning: variable "file" is unused
  lib/mix/tasks/extract.ex:70

warning: variable "locale" is unused
  lib/mix/tasks/extract.ex:70
```